### PR TITLE
Feature/db migrations

### DIFF
--- a/Necromancy.Server/Database/IDatabase.cs
+++ b/Necromancy.Server/Database/IDatabase.cs
@@ -6,6 +6,12 @@ namespace Necromancy.Server.Database
 {
     public interface IDatabase
     {
+        long Version
+        {
+            get;
+            set;
+        }
+
         void Execute(string sql);
 
         /// <summary>

--- a/Necromancy.Server/Database/NecDatabaseBuilder.cs
+++ b/Necromancy.Server/Database/NecDatabaseBuilder.cs
@@ -37,7 +37,7 @@ namespace Necromancy.Server.Database
 
         private NecSqLiteDb PrepareSqlLiteDb(string sqLiteFolder)
         {
-            string sqLitePath = Path.Combine(sqLiteFolder, $"db.v{NecSqLiteDb.Version}.sqlite");
+            string sqLitePath = Path.Combine(sqLiteFolder, $"db.sqlite");
             NecSqLiteDb db = new NecSqLiteDb(sqLitePath);
             if (db.CreateDatabase())
             {

--- a/Necromancy.Server/Database/NecDatabaseBuilder.cs
+++ b/Necromancy.Server/Database/NecDatabaseBuilder.cs
@@ -52,9 +52,9 @@ namespace Necromancy.Server.Database
                 scriptRunner.Run(Path.Combine(sqLiteFolder, "Script/data_auction.sql"));
                 scriptRunner.Run(Path.Combine(sqLiteFolder, "Script/data_gimmick.sql"));
                 scriptRunner.Run(Path.Combine(sqLiteFolder, "Script/data_maptransition.sql"));
-
             }
 
+            new SqlMigrator(db).Migrate(Path.Combine(sqLiteFolder, "Script/Migrations/"));
             return db;
         }
     }

--- a/Necromancy.Server/Database/Script/Migrations/0-sample-migration.sql
+++ b/Necromancy.Server/Database/Script/Migrations/0-sample-migration.sql
@@ -1,0 +1,4 @@
+/* Migration file naming scheme <version>-<feature>.sql
+   Place ALTER TABLE and INSERT statements in these files to update table columns.
+   New DB version should be set in C# to make .sql files cross-compatible.
+*/

--- a/Necromancy.Server/Database/Sql/NecMariaDb.cs
+++ b/Necromancy.Server/Database/Sql/NecMariaDb.cs
@@ -16,6 +16,16 @@ namespace Necromancy.Server.Database.Sql
 
         private string _connectionString;
 
+        public long Version
+        {
+            get {
+                return (long)long.Parse(Command("SELECT @@GLOBAL.user_version;", Connection()).ExecuteScalar().ToString());
+            }
+            set {
+                Command(String.Format("SET GLOBAL user_version = {0};", value), Connection()).ExecuteNonQuery();
+            }
+        }
+
         public bool CreateDatabase()
         {
             throw new NotImplementedException();

--- a/Necromancy.Server/Database/Sql/NecSqLiteDb.cs
+++ b/Necromancy.Server/Database/Sql/NecSqLiteDb.cs
@@ -11,7 +11,15 @@ namespace Necromancy.Server.Database.Sql
     public class NecSqLiteDb : NecSqlDb<SQLiteConnection, SQLiteCommand>, IDatabase
     {
         public const string MemoryDatabasePath = ":memory:";
-        public const int Version = 1;
+        public long Version
+        {
+            get {
+                return (long)Command("PRAGMA user_version;", Connection()).ExecuteScalar();
+            }
+            set {
+                Command(String.Format("PRAGMA user_version = {0};", value), Connection()).ExecuteNonQuery();
+            }
+        }
 
         private const string SelectAutoIncrement = "SELECT last_insert_rowid()";
 

--- a/Necromancy.Server/Database/Sql/SqlMigrator.cs
+++ b/Necromancy.Server/Database/Sql/SqlMigrator.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using Arrowgene.Services.Logging;
+
+namespace Necromancy.Server.Database.Sql
+{
+    /// <summary>
+    /// Apply SQL migrations to a database with a set of SQL migration scripts.
+    /// </summary>
+    public class SqlMigrator
+    {
+        /// <summary>The SQL database to apply migrations to.</summary>
+        public IDatabase Database { get; set; }
+
+        private readonly ILogger _logger;
+
+        /// <param name="database">The SQL database to apply migrations to.</param>
+        public SqlMigrator(IDatabase database)
+        {
+            Database = database;
+            _logger = LogProvider.Logger(this);
+        }
+
+        /// <summary>
+        /// Apply all new migrations, by version number, in the given database migrations folder.
+        /// </summary>
+        /// <param name="migrationsFolder">Database migrations folder.</param>
+        /// <remarks>
+        /// SQL migration file names must start with a version number, and end with the .sql extension.
+        /// There is only one migration file per version number.
+        /// Throws ArgumentException if two migration files have the same version.
+        /// Throws ArgumentException if the version=>file dictionary does not give us the keys in order.
+        /// Throws FormatException on file name format error.
+        /// </remarks>
+        public void Migrate(string migrationsFolder)
+        {
+            long initialVersion = Database.Version, versionNumber = 0;
+            var versionFileDict = new SortedList<long, string>();
+            /* Prepare migration files, ordered by version number. */
+            foreach (var f in Directory.GetFiles(migrationsFolder, "*.sql"))
+            {
+                /* Migration naming scheme: [0-9]+-<description>.sql */
+                if (!long.TryParse(Regex.Match(Path.GetFileName(f), @"\d+").Value, NumberStyles.None,
+                    NumberFormatInfo.InvariantInfo, out versionNumber))
+                {
+                    LogException(new FormatException(String.Format(
+                        "Failed to detect DB version for migration file: {0}. File name should begin with a database version number.",
+                        f)));
+                }
+                /* Ignore 0-version, this is an example. Adding the same version twice will throw
+                   an ArgumentException. */
+                if (versionNumber > initialVersion)
+                    versionFileDict.Add(versionNumber, f);
+            }
+            ApplyMigrations(versionFileDict);
+            if ((versionNumber = Database.Version) > initialVersion)
+            {
+                _logger.Debug("Database db.sqlite version is updated to {0}.", versionNumber);
+            }
+        }
+
+        /// <summary>
+        /// Apply all migrations in-order per sql file, and update the DB version.
+        /// </summary>
+        /// <param name="versionFileDict">Map of version number to migration file path.
+        /// The keys are required to be sorted to apply in order.</param>
+        /// <remarks>
+        /// Throws ArgumentException if the version=>file dictionary does not give us the keys in order.
+        /// </remarks>
+        private void ApplyMigrations(IDictionary<long, string> versionFileDict)
+        {
+            long initialVersion = Database.Version, versionNumber = 0;
+            ScriptRunner scriptRunner = new ScriptRunner(Database);
+            /* Assert: All entries' version is above current DB version. */
+            foreach (KeyValuePair<long, string> kvp in versionFileDict)
+            {
+                /* Assert: Keys are in-order to apply migrations in-order. */
+                if (kvp.Key < versionNumber)
+                {
+                    LogException(new ArgumentException(
+                        "A sorted list's keys are out of order, and expected to be in-order."));
+                }
+                scriptRunner.Run(kvp.Value);
+                Database.Version = versionNumber = kvp.Key;
+            }
+        }
+
+        /// <summary>
+        /// Log the given exception and throw as a runtime error.
+        /// </summary>
+        private void LogException(Exception exception)
+        {
+            _logger.Error(exception.Message);
+            _logger.Exception(exception);
+            throw exception;
+        }
+    }
+}

--- a/Necromancy.Test/Database/NecDatabaseBuilderTest.cs
+++ b/Necromancy.Test/Database/NecDatabaseBuilderTest.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+using Necromancy.Server.Database;
+using Necromancy.Server.Setting;
+
+namespace Necromancy.Test.Database
+{
+    public class NecDatabaseBuilderTest
+    {
+        [Fact]
+        public void TestBuild()
+        {
+            /* Confirm successful build with currently configured database. */
+            NecSetting settings = new NecSetting();
+            new NecDatabaseBuilder().Build(settings.DatabaseSettings);
+        }
+    }
+}

--- a/Necromancy.Test/Database/Sql/SqlMigratorTest.cs
+++ b/Necromancy.Test/Database/Sql/SqlMigratorTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+using Necromancy.Server.Database;
+using Necromancy.Server.Database.Sql;
+
+namespace Necromancy.Test.Database.Sql
+{
+    public class SqlMigratorTest
+    {
+        private const string SQLITE_FILE = "TestMigrations/db.sqlite";
+        private const string MIGRATION_DIR = "TestMigrations/Script/Migrations/";
+        private const string FIRST = MIGRATION_DIR + "1-first.sql";
+        private const string SECOND = MIGRATION_DIR + "2.sql";
+        /* 0 is a sample and will be silently ignored. */
+        private const string IGNORE_ZERO = MIGRATION_DIR + "0.sql";
+        /* Non-sql files should be ignored. */
+        private const string IGNORE_TEXT = MIGRATION_DIR + "notsql.txt";
+        /* Same version, will throw ArgumentException. */
+        private const string FAIL_DUPLICATE = MIGRATION_DIR + "1-dup.sql";
+        /* No version, will throw FormatException. */
+        private const string FAIL_NOVERSION = MIGRATION_DIR + "noversion.sql";
+
+        private readonly ITestOutputHelper _output;
+
+        public SqlMigratorTest(ITestOutputHelper output)
+        {
+            _output = output;
+
+            /* Create an artificial migrations environment to test specific requirements. */
+            PrepFiles();
+        }
+
+        [Fact]
+        public void TestSqlLite()
+        {
+            IDatabase db = new NecSqLiteDb(SQLITE_FILE);
+            db.CreateDatabase();
+            Assert.Equal(0, db.Version);
+
+            /* Valid case, no errors. */
+            TestValid(db);
+
+            /* Test sync */
+            IDatabase db2 = new NecSqLiteDb(SQLITE_FILE);
+            db.CreateDatabase();
+            db.Version = 11;
+            Assert.Equal(11, db.Version);
+            Assert.Equal(11, db2.Version);
+            db2.Version = 12;
+            Assert.Equal(12, db.Version);
+            Assert.Equal(12, db2.Version);
+
+            /* Reset */
+            db.Version = 0;
+            Assert.Equal(0, db.Version);
+
+            /* Invalid case, errors are thrown. */
+            TestInvalid(db);
+        }
+
+        [Fact]
+        public void TestSortedKeys()
+        {
+            /* Prep data random */
+            Random random = new Random();
+            int length = random.Next(5, 100);
+            int current;
+            int[] versionList = new int[length];
+            SortedList<int, string> list = new SortedList<int, string>();
+            for (int i = 0; i < length; i++)
+            {
+                current = random.Next(1, 100);
+                versionList[i] = current;
+                if (!list.ContainsKey(current))
+                    list[current] = "NONAME";
+            }
+
+            /* Finally assert list iterates in the sorted order. */
+            current = 0;
+            foreach (KeyValuePair<int, string> kvp in list)
+            {
+                Assert.True(kvp.Key > current);
+                Assert.Equal("NONAME", kvp.Value);
+                current = kvp.Key;
+            }
+
+            _output.WriteLine(String.Format(
+                "SortedList iterates successfully in sorted order for {0} integers, and a total of {1} inserted values.",
+                length, list.Count));
+        }
+
+        private void TestValid(IDatabase db)
+        {
+            SqlMigrator migrator = new SqlMigrator(db);
+            migrator.Migrate(MIGRATION_DIR);
+            /* Highest migration version = 2. */
+            Assert.Equal(2, db.Version);
+            db.Version = 0;
+            Assert.Equal(0, db.Version);
+        }
+
+        private void TestInvalid(IDatabase db)
+        {
+            SqlMigrator migrator = new SqlMigrator(db);
+
+            /* FAIL_DUPLICATE migration file is a version duplicate. */
+            Create(FAIL_DUPLICATE);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                migrator.Migrate(MIGRATION_DIR);
+            });
+            File.Delete(FAIL_DUPLICATE);
+
+            /* FAIL_NOVERSION migration file has an invalid name, with no version. */
+            Create(FAIL_NOVERSION);
+            Assert.Throws<FormatException>(() =>
+            {
+                migrator.Migrate(MIGRATION_DIR);
+            });
+            File.Delete(FAIL_NOVERSION);
+        }
+
+        private void PrepFiles()
+        {
+            if (!Directory.Exists(MIGRATION_DIR))
+                Directory.CreateDirectory(MIGRATION_DIR);
+            Create(FIRST);
+            Create(SECOND);
+            Create(IGNORE_ZERO);
+            Create(IGNORE_TEXT);
+
+            /* Clean the runs with errors. */
+            if (File.Exists(FAIL_DUPLICATE))
+                File.Delete(FAIL_DUPLICATE);
+            if (File.Exists(FAIL_NOVERSION))
+                File.Delete(FAIL_NOVERSION);
+        }
+
+        private void Create(string fileName)
+        {
+            if (!File.Exists(fileName))
+                File.Create(fileName).Close();
+        }
+    }
+}

--- a/Necromancy.Test/Necromancy.Test.csproj
+++ b/Necromancy.Test/Necromancy.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Necromancy.Test/Necromancy.Test.csproj
+++ b/Necromancy.Test/Necromancy.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
+    <PackageReference Include="xunit" Version="2.4.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
+    <PackageReference Include="coverlet.collector" Version="1.0.1"/>
+    <PackageReference Include="dotnet-xunit" Version="*"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Necromancy.Server\Necromancy.Server.csproj"/>
+    <ProjectReference Include="..\Necromancy.Cli\Necromancy.Cli.csproj"/>
+  </ItemGroup>
+</Project>

--- a/Necromancy.sln
+++ b/Necromancy.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Necromancy.Server", "Necrom
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Necromancy.Cli", "Necromancy.Cli\Necromancy.Cli.csproj", "{435A4CE2-B4EC-4112-8F6A-5FC0F54000AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Necromancy.Test", "Necromancy.Test\Necromancy.Test.csproj", "{75B94843-9CE6-4E2C-AEB6-4C708877BD43}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{435A4CE2-B4EC-4112-8F6A-5FC0F54000AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{435A4CE2-B4EC-4112-8F6A-5FC0F54000AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{435A4CE2-B4EC-4112-8F6A-5FC0F54000AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75B94843-9CE6-4E2C-AEB6-4C708877BD43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75B94843-9CE6-4E2C-AEB6-4C708877BD43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75B94843-9CE6-4E2C-AEB6-4C708877BD43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75B94843-9CE6-4E2C-AEB6-4C708877BD43}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add database migrations

All migration files must be named beginning with the version the Database will become after applying
this script, and end with the .sql extension.
IDatabase, NecSqLiteDb, NecMariaDb: Implement a Version property.
NecDatabaseBuilder: Use SqlMigrator to apply migrations in the folder "Necromancy.Server/Database/Script/Migrations/"
Add Necromancy.Test testing project, and add DB and migration tests.