### PR TITLE
Remove Clients from ClientLookup on Disconnect.

### DIFF
--- a/Necromancy.Server/Chat/Command/Commands/PlayersCommand.cs
+++ b/Necromancy.Server/Chat/Command/Commands/PlayersCommand.cs
@@ -32,7 +32,7 @@ namespace Necromancy.Server.Chat.Command.Commands
                 case "map": //tells you all the people on the Map you're on
                     foreach (NecClient theirClient in client.Map.ClientLookup.GetAll())
                     {
-                        if(theirClient.Map.Id != -1 && theirClient.Character.InstanceId != 0)
+                        //if(theirClient.Map.Id != -1 && theirClient.Character.InstanceId != 0)
                             responses.Add(ChatResponse.CommandError(client,
                                 $"{theirClient.Character.Name} {theirClient.Soul.Name} is on Map {theirClient.Character.MapId} with InstanceID {theirClient.Character.InstanceId}"));
                     }
@@ -42,7 +42,7 @@ namespace Necromancy.Server.Chat.Command.Commands
                 case "world": //tells you all the people in the world
                     foreach (NecClient theirClient in Server.Clients.GetAll())
                     {
-                        if (theirClient.Map.Id != -1 && theirClient.Character.InstanceId != 0)
+                        //if (theirClient.Map.Id != -1 && theirClient.Character.InstanceId != 0)
                             responses.Add(ChatResponse.CommandError(client,
                                 $"{theirClient.Character.Name} {theirClient.Soul.Name} is on Map {theirClient.Character.MapId} with InstanceID {theirClient.Character.InstanceId}"));
                     }

--- a/Necromancy.Server/NecServer.cs
+++ b/Necromancy.Server/NecServer.cs
@@ -142,6 +142,9 @@ namespace Necromancy.Server
             {
                 union.Leave(client);
             }
+
+            //Remove the client from the list of server clients on disconnect
+            this.Clients.Remove(client);
         }
 
         public void Start()


### PR DESCRIPTION
a fix for the /players world  command showing a bunch of clients with -1 instance IDs