### PR TITLE
Renaming Columns and variables

### DIFF
--- a/Necromancy.Server/Database/IDatabase.cs
+++ b/Necromancy.Server/Database/IDatabase.cs
@@ -111,7 +111,7 @@ namespace Necromancy.Server.Database
         //Union
         bool InsertUnion(Union union);
         Union SelectUnionById(int unionId);
-        Union SelectUnionByUnionLeaderId(int leaderId);
+        Union SelectUnionByLeaderId(int leaderId);
         Union SelectUnionByName(string unionName);
         bool UpdateUnion(Union union);
         bool DeleteUnion(int unionId);

--- a/Necromancy.Server/Database/Script/data_union.sql
+++ b/Necromancy.Server/Database/Script/data_union.sql
@@ -1,8 +1,8 @@
 
- INSERT INTO "nec_union" ("id","name","union_leader_id","union_sub_leader1_id","union_sub_leader2_id","level","current_exp","next_level_exp","member_limit_increase","cape_design_id","union_news","created") 
+ INSERT INTO "nec_union" ("id","name","leader_character_id","subleader1_character_id","subleader2_character_id","level","current_exp","next_level_exp","member_limit_increase","cape_design_id","union_news","created") 
  VALUES 
  (1,'DefaultUnion',1,0,0,0,0,100,0,0,NULL,'2020-02-11 13:26:55.9224609'),
- (2,'Trade_Union',9,0,0,0,0,100,0,0,NULL,'2020-02-11 15:20:31.4537755');
+ (2,'Trade_Union',9,2,0,0,0,100,0,0,NULL,'2020-02-11 15:20:31.4537755');
 
 INSERT INTO "nec_union_member" ("id","union_id","character_id","member_priviledge_bitmask","rank","joined") 
 VALUES 

--- a/Necromancy.Server/Database/Script/schema_sqlite.sql
+++ b/Necromancy.Server/Database/Script/schema_sqlite.sql
@@ -211,19 +211,21 @@ CREATE TABLE IF NOT EXISTS `nec_block_list`
 
 CREATE TABLE IF NOT EXISTS `nec_union`
 (
-    `id`                    INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,
-    `name`                  TEXT     NOT NULL,
+    `id`                        INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,
+    `name`                      TEXT     NOT NULL,
     `leader_character_id`       INTEGER  NOT NULL,
-    `subleader1_character_id`  INTEGER,
-    `subleader2_character_id`  INTEGER,
-    `level`                 INTEGER  NOT NULL,
-    `current_exp`           INTEGER  NOT NULL,
-    `next_level_exp`        INTEGER  NOT NULL,
-    `member_limit_increase` INTEGER  NOT NULL,
-    `cape_design_id`        INTEGER,
-    `union_news`            TEXT,
-    `created`               DATETIME NOT NULL,
-    FOREIGN KEY (`leader_character_id`) REFERENCES `nec_character` (`id`)
+    `subleader1_character_id`   INTEGER,
+    `subleader2_character_id`   INTEGER,
+    `level`                     INTEGER  NOT NULL,
+    `current_exp`               INTEGER  NOT NULL,
+    `next_level_exp`            INTEGER  NOT NULL,
+    `member_limit_increase`     INTEGER  NOT NULL,
+    `cape_design_id`            INTEGER,
+    `union_news`                TEXT,
+    `created`                   DATETIME NOT NULL,
+    CONSTRAINT `fk_nec_union_leader_character_id` FOREIGN KEY (`leader_character_id`) REFERENCES `nec_character` (`id`)
+    CONSTRAINT `fk_nec_union_subleader1_character_id` FOREIGN KEY (`subleader1_character_id`) REFERENCES `nec_character` (`id`)
+    CONSTRAINT `fk_nec_union_subleader2_character_id` FOREIGN KEY (`subleader2_character_id`) REFERENCES `nec_character` (`id`)
 );
 
 CREATE TABLE IF NOT EXISTS `nec_union_member`

--- a/Necromancy.Server/Database/Script/schema_sqlite.sql
+++ b/Necromancy.Server/Database/Script/schema_sqlite.sql
@@ -213,9 +213,9 @@ CREATE TABLE IF NOT EXISTS `nec_union`
 (
     `id`                    INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,
     `name`                  TEXT     NOT NULL,
-    `union_leader_id`       INTEGER  NOT NULL,
-    `union_sub_leader1_id`  INTEGER,
-    `union_sub_leader2_id`  INTEGER,
+    `leader_character_id`       INTEGER  NOT NULL,
+    `subleader1_character_id`  INTEGER,
+    `subleader2_character_id`  INTEGER,
     `level`                 INTEGER  NOT NULL,
     `current_exp`           INTEGER  NOT NULL,
     `next_level_exp`        INTEGER  NOT NULL,
@@ -223,7 +223,7 @@ CREATE TABLE IF NOT EXISTS `nec_union`
     `cape_design_id`        INTEGER,
     `union_news`            TEXT,
     `created`               DATETIME NOT NULL,
-    FOREIGN KEY (`union_leader_id`) REFERENCES `nec_character` (`id`)
+    FOREIGN KEY (`leader_character_id`) REFERENCES `nec_character` (`id`)
 );
 
 CREATE TABLE IF NOT EXISTS `nec_union_member`

--- a/Necromancy.Server/Database/Sql/Core/NecSqlDbUnion.cs
+++ b/Necromancy.Server/Database/Sql/Core/NecSqlDbUnion.cs
@@ -9,20 +9,20 @@ namespace Necromancy.Server.Database.Sql.Core
         where TCom : DbCommand
     {
         private const string SqlInsertUnion =
-            "INSERT INTO `nec_union` (`name`,`union_leader_id`,`union_sub_leader1_id`,`union_sub_leader2_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created`)VALUES(@name,@union_leader_id,@union_sub_leader1_id,@union_sub_leader2_id,@level,@current_exp,@next_level_exp,@member_limit_increase,@cape_design_id,@union_news,@created);";
+            "INSERT INTO `nec_union` (`name`,`leader_character_id`,`subleader1_character_id`,`subleader2_character_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created`)VALUES(@name,@leader_character_id,@subleader1_character_id,@subleader2_character_id,@level,@current_exp,@next_level_exp,@member_limit_increase,@cape_design_id,@union_news,@created);";
         
         private const string SqlSelectUnionById =
-            "SELECT `id`,`name`,`union_leader_id`,`union_sub_leader1_id`,`union_sub_leader2_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `id`=@id;";
+            "SELECT `id`,`name`,`leader_character_id`,`subleader1_character_id`,`subleader2_character_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `id`=@id;";
 
-        private const string SqlSelectUnionByUnionLeaderId =
-            "SELECT `id`,`name`,`union_leader_id`,`union_sub_leader1_id`,`union_sub_leader2_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `union_leader_id`=@union_leader_id;";
+        private const string SqlSelectUnionByLeaderId =
+            "SELECT `id`,`name`,`leader_character_id`,`subleader1_character_id`,`subleader2_character_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `leader_character_id`=@leader_character_id;";
         
         private const string SqlSelectUnionByName =
-            "SELECT `id`,`name`,`union_leader_id`,`union_sub_leader1_id`,`union_sub_leader2_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `name`=@name;";
+            "SELECT `id`,`name`,`leader_character_id`,`subleader1_character_id`,`subleader2_character_id`,`level`,`current_exp`,`next_level_exp`,`member_limit_increase`,`cape_design_id`,`union_news`,`created` FROM `nec_union` WHERE `name`=@name;";
 
 
         private const string SqlUpdateUnion =
-            "UPDATE `nec_union` SET `id`=@id,`name`=@name,`union_leader_id`=@union_leader_id,`union_sub_leader1_id`=@union_sub_leader1_id,`union_sub_leader2_id`=@union_sub_leader2_id,`level`=@level,`current_exp`=@current_exp,`next_level_exp`=@next_level_exp,`member_limit_increase`=@member_limit_increase,`cape_design_id`=@cape_design_id,`union_news`=@union_news,`created`=@created WHERE `id`=@id;";
+            "UPDATE `nec_union` SET `id`=@id,`name`=@name,`leader_character_id`=@leader_character_id,`subleader1_character_id`=@subleader1_character_id,`subleader2_character_id`=@subleader2_character_id,`level`=@level,`current_exp`=@current_exp,`next_level_exp`=@next_level_exp,`member_limit_increase`=@member_limit_increase,`cape_design_id`=@cape_design_id,`union_news`=@union_news,`created`=@created WHERE `id`=@id;";
 
         private const string SqlDeleteUnion =
             "DELETE FROM `nec_union` WHERE `id`=@id;";
@@ -33,9 +33,9 @@ namespace Necromancy.Server.Database.Sql.Core
             {
                 //AddParameter(command, "@id", union.Id);
                 AddParameter(command, "@name", union.Name);
-                AddParameter(command, "@union_leader_id", union.UnionLeaderId);
-                AddParameter(command, "@union_sub_leader1_id", union.UnionSubLeader1Id);
-                AddParameter(command, "@union_sub_leader2_id", union.UnionSubLeader2Id);
+                AddParameter(command, "@leader_character_id", union.LeaderId);
+                AddParameter(command, "@subleader1_character_id", union.SubLeader1Id);
+                AddParameter(command, "@subleader2_character_id", union.SubLeader2Id);
                 AddParameter(command, "@level", union.Level);
                 AddParameter(command, "@current_exp", union.CurrentExp);
                 AddParameter(command, "@next_level_exp", union.NextLevelExp);
@@ -66,11 +66,11 @@ namespace Necromancy.Server.Database.Sql.Core
                 });
             return union;
         }
-        public Union SelectUnionByUnionLeaderId(int leaderId)
+        public Union SelectUnionByLeaderId(int leaderId)
         {
             Union union = null;
-            ExecuteReader(SqlSelectUnionByUnionLeaderId,
-                command => { AddParameter(command, "@union_leader_id", leaderId); }, reader =>
+            ExecuteReader(SqlSelectUnionByLeaderId,
+                command => { AddParameter(command, "@leader_character_id", leaderId); }, reader =>
                 {
                     if (reader.Read())
                     {
@@ -100,9 +100,9 @@ namespace Necromancy.Server.Database.Sql.Core
             {
                 AddParameter(command, "@id", union.Id);
                 AddParameter(command, "@name", union.Name);
-                AddParameter(command, "@union_leader_id", union.UnionLeaderId);
-                AddParameter(command, "@union_sub_leader1_id", union.UnionSubLeader1Id);
-                AddParameter(command, "@union_sub_leader2_id", union.UnionSubLeader2Id);
+                AddParameter(command, "@leader_character_id", union.LeaderId);
+                AddParameter(command, "@subleader1_character_id", union.SubLeader1Id);
+                AddParameter(command, "@subleader2_character_id", union.SubLeader2Id);
                 AddParameter(command, "@level", union.Level);
                 AddParameter(command, "@current_exp", union.CurrentExp);
                 AddParameter(command, "@next_level_exp", union.NextLevelExp);
@@ -126,9 +126,9 @@ namespace Necromancy.Server.Database.Sql.Core
                 Union union = new Union();
                 union.Id = GetInt32(reader, "id");
                 union.Name = GetStringNullable(reader, "name");
-                union.UnionLeaderId = GetInt32(reader, "union_leader_id");
-                union.UnionSubLeader1Id = GetInt32(reader, "union_sub_leader1_id");
-                union.UnionSubLeader2Id = GetInt32(reader, "union_sub_leader1_id");
+                union.LeaderId = GetInt32(reader, "leader_character_id");
+                union.SubLeader1Id = GetInt32(reader, "subleader1_character_id");
+                union.SubLeader2Id = GetInt32(reader, "subleader1_character_id");
                 union.Level = (uint)GetInt32(reader, "level");
                 union.CurrentExp = (uint)GetInt32(reader, "current_exp");
                 union.NextLevelExp = (uint)GetInt32(reader, "next_level_exp");

--- a/Necromancy.Server/Model/Union/Union.cs
+++ b/Necromancy.Server/Model/Union/Union.cs
@@ -10,9 +10,9 @@ namespace Necromancy.Server.Model.Union
         public uint InstanceId { get; set; }
         public int Id { get; set; }
         public string Name { get; set; }
-        public int UnionLeaderId { get; set; }
-        public int UnionSubLeader1Id { get; set; }
-        public int UnionSubLeader2Id { get; set; }
+        public int LeaderId { get; set; }
+        public int SubLeader1Id { get; set; }
+        public int SubLeader2Id { get; set; }
         public uint Level { get; set; }
         public uint CurrentExp { get; set; }
         public uint NextLevelExp { get; set; }
@@ -28,7 +28,7 @@ namespace Necromancy.Server.Model.Union
             UnionMembers = new List<NecClient>();
             Id = -1;
             Name = "";
-            UnionLeaderId = 0;
+            LeaderId = 0;
             Level = 0;
             CurrentExp = 0;
             NextLevelExp = 100;

--- a/Necromancy.Server/Packet/Area/send_party_apply.cs
+++ b/Necromancy.Server/Packet/Area/send_party_apply.cs
@@ -38,7 +38,7 @@ namespace Necromancy.Server.Packet.Area
             res2.WriteFixedString($"{client.Character.Name}", 0x5B);
             res2.WriteUInt32(client.Character.ClassId);
             res2.WriteByte(client.Character.Level);
-            res2.WriteByte(2); //Criminal Status
+            res2.WriteByte(client.Character.criminalState); //Criminal Status
             res2.WriteByte(1); //Beginner Protection (bool) 
             res2.WriteByte(1); //Membership Status
             res2.WriteByte(1);

--- a/Necromancy.Server/Packet/Area/send_union_request_detail.cs
+++ b/Necromancy.Server/Packet/Area/send_union_request_detail.cs
@@ -97,9 +97,9 @@ namespace Necromancy.Server.Packet.Msg
                         Router.Send(client, (ushort) MsgPacketId.recv_union_notify_detail_member, res3, ServerType.Msg);
                     }
 
-                    uint UnionLeaderInstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionLeaderId);
-                    uint UnionSubLeader1InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionSubLeader1Id);
-                    uint UnionSubLeader2InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionSubLeader2Id);
+                    uint UnionLeaderInstanceId = Server.Instances.GetCharacterInstanceId(myUnion.LeaderId);
+                    uint UnionSubLeader1InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.SubLeader1Id);
+                    uint UnionSubLeader2InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.SubLeader2Id);
 
                     //Notify client if msg server found Union settings in database(memory) for client character Unique Persistant ID.
                     IBuffer res = BufferProvider.Provide();

--- a/Necromancy.Server/Packet/Area/send_union_request_establish.cs
+++ b/Necromancy.Server/Packet/Area/send_union_request_establish.cs
@@ -77,7 +77,7 @@ namespace Necromancy.Server.Packet.Area
             Server.Instances.AssignInstance(myFirstUnion);
             client.Character.unionId = (int) myFirstUnion.InstanceId;
             myFirstUnion.Name = unionName;
-            myFirstUnion.UnionLeaderId = client.Character.Id;
+            myFirstUnion.LeaderId = client.Character.Id;
             client.Union = myFirstUnion;
 
             if (!Server.Database.InsertUnion(myFirstUnion))

--- a/Necromancy.Server/Packet/Msg/send_union_reply_to_invite2.cs
+++ b/Necromancy.Server/Packet/Msg/send_union_reply_to_invite2.cs
@@ -29,7 +29,7 @@ namespace Necromancy.Server.Packet.Msg
                 $"replyToInstanceId {replyToInstanceId} resultAcceptOrDeny {resultAcceptOrDeny} replyToClient.Character.unionId {replyToClient.Character.unionId}");
 
             //Union myUnion = Server.Instances.GetInstance(replyToClient.Character.unionId) as Union;
-            Union myUnion = Server.Database.SelectUnionByUnionLeaderId(replyToClient.Character.Id);
+            Union myUnion = Server.Database.SelectUnionByLeaderId(replyToClient.Character.Id);
             Logger.Debug($"my union is {myUnion.Name}");
             IBuffer res5 = BufferProvider.Provide();
 
@@ -56,9 +56,9 @@ namespace Necromancy.Server.Packet.Msg
 
                 Logger.Debug($"union member ID{myUnionMember.Id} added to nec_union_member table");
 
-                uint UnionLeaderInstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionLeaderId);
-                uint UnionSubLeader1InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionSubLeader1Id);
-                uint UnionSubLeader2InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.UnionSubLeader2Id);
+                uint UnionLeaderInstanceId = Server.Instances.GetCharacterInstanceId(myUnion.LeaderId);
+                uint UnionSubLeader1InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.SubLeader1Id);
+                uint UnionSubLeader2InstanceId = Server.Instances.GetCharacterInstanceId(myUnion.SubLeader2Id);
 
                 TimeSpan difference = client.Union.Created.ToUniversalTime() - DateTime.UnixEpoch;
                 int unionCreatedCalculation = (int) Math.Floor(difference.TotalSeconds);

--- a/Necromancy.Server/Packet/Msg/send_union_request_set_info.cs
+++ b/Necromancy.Server/Packet/Msg/send_union_request_set_info.cs
@@ -31,7 +31,6 @@ namespace Necromancy.Server.Packet.Msg
             Router.Send(client, (ushort) MsgPacketId.recv_union_request_set_info_r, res, ServerType.Msg);
 
             //ToDo
-            //Notify all union members immediatly that news has changed 
             //L"network::proto_msg_implement_client::recv_union_notify_info()\n"
             //Permissions check for news updating based on 'newsUpdatedByInstanceId'. Returns 0 or 1709
             //Naughty word scrubbing for 'banned words' returns 1715
@@ -42,7 +41,7 @@ namespace Necromancy.Server.Packet.Msg
             res2.WriteInt32(0); //Error check probably.  0 means success?
             res2.WriteCString($"{unionNews}"); //max size 0x196
 
-            Router.Send(client.Map /*myUnion.UnionMembers*/, (ushort) MsgPacketId.recv_union_notify_info, res2,
+            Router.Send(client.Union.UnionMembers, (ushort) MsgPacketId.recv_union_notify_info, res2,
                 ServerType.Msg);
         }
     }


### PR DESCRIPTION
A simple feature update to rename some union related columns and variables to remove the redundant word 'union'. 

Successful test criteria: delete your local DB, start the server, login as 1234/1234 Xeno.Talin confirm you see other union members and are a member of a union.