### PR TITLE
Update SendChatPostMessageDeserializer.cs

### DIFF
--- a/Necromancy.Server/Packet/Area/SendChatPostMessage/SendChatPostMessageDeserializer.cs
+++ b/Necromancy.Server/Packet/Area/SendChatPostMessage/SendChatPostMessageDeserializer.cs
@@ -24,6 +24,7 @@ namespace Necromancy.Server.Packet.Area.SendChatPostMessage
 
             ChatMessageType messageType = (ChatMessageType) messageTypeValue;
             string recipient = packet.Data.ReadCString();
+            int unknown = packet.Data.ReadInt32(); //Not sure what this is, it is new from JP client. Might be talk ring related.
             string message = packet.Data.ReadCString();
 
             return new ChatMessage(messageType, recipient, message);


### PR DESCRIPTION
Fixed chat handler allowing for people to once again communicate in the world of Wizardry Online. One day the private server gods said no more communication, but today we at Necromancy Online say "Let the people talk again!".