### PR TITLE
Fix shop

### DIFF
--- a/Necromancy.Server/Packet/Area/send_event_select_exec_r.cs
+++ b/Necromancy.Server/Packet/Area/send_event_select_exec_r.cs
@@ -677,64 +677,75 @@ namespace Necromancy.Server.Packet.Area
             res.WriteInt32(2);
             Router.Send(client, (ushort)AreaPacketId.recv_situation_start, res, ServerType.Area);
 
-            if (client.Character.eventSelectExecCode == 0)
-            {
-                List<ItemInfoSetting> Weaponlist = new List<ItemInfoSetting>();
-                foreach (ItemInfoSetting weapon in Server.SettingRepository.ItemInfo.Values)
-                {
-                    if (weapon.Id > 10100101 & weapon.Id < 15300101)
-                    {
-                        Weaponlist.Add(weapon);
-                    }
-                }
+            ItemLocation nextOpenLocation = client.Character.ItemManager.NextOpenSlot(ItemZoneType.AdventureBag);
 
-                int baseId = Weaponlist[Util.GetRandomNumber(0, Weaponlist.Count)].Id;
-                itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
-
-                RecvItemInstanceUnidentified recvItemInstanceUnidentified = new RecvItemInstanceUnidentified(client, itemInstance, (byte)itemInstance.Location.ZoneType);
-                Router.Send(client, recvItemInstanceUnidentified.ToPacket());
-            }
-            else if (client.Character.eventSelectExecCode == 1)
-            {
-                List<ItemInfoSetting> ArmorList = new List<ItemInfoSetting>();
-                foreach (ItemInfoSetting armor in Server.SettingRepository.ItemInfo.Values)
-                {
-                    if (armor.Id > 16100101 & armor.Id < 30499901)
-                    {
-                        ArmorList.Add(armor);
-                    }
-                }
-
-                int baseId = ArmorList[Util.GetRandomNumber(0, ArmorList.Count)].Id;
-                itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
-
-                RecvItemInstanceUnidentified recvItemInstanceUnidentified = new RecvItemInstanceUnidentified(client, itemInstance, (byte)itemInstance.Location.ZoneType);
-                Router.Send(client, recvItemInstanceUnidentified.ToPacket());
-            }
-            else if (client.Character.eventSelectExecCode == 2)
-            { //50401040,Moist Cudgel
-                int baseId = 50401040; //This can select from a small array of items, and a small array of custom names
-                spawmParam.ItemStatuses = ItemStatuses.Identified;
-                itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
-
-                RecvItemInstance recvItemInstance = new RecvItemInstance(client, itemInstance);
-                Router.Send(client, recvItemInstance.ToPacket());
-            }
-
-            if (itemInstance == null)
+            if (nextOpenLocation.ZoneType == ItemZoneType.InvalidZone)
             {
                 res = BufferProvider.Provide();
-                res.WriteCString("Better Luck Next Time.  I ran out of items!"); // Length 0xC01
+                res.WriteCString($"Your Adventure Bag is full.  Go away already! {client.Soul.Name}"); // Length 0xC01
                 Router.Send(client, (ushort)AreaPacketId.recv_event_system_message, res, ServerType.Area); // show system message on middle of the screen.
-                res = BufferProvider.Provide();
-                Router.Send(client, (ushort)AreaPacketId.recv_situation_end, res, ServerType.Area);
-                RecvEventEnd(client); //End The Event 
-                return;
             }
-            res = BufferProvider.Provide();
-            res.WriteCString($"Enjoy your new Super {itemInstance.UnidentifiedName}"); // Length 0xC01
-            Router.Send(client, (ushort)AreaPacketId.recv_event_system_message, res, ServerType.Area); // show system message on middle of the screen.
+            else
+            {
 
+                if (client.Character.eventSelectExecCode == 0)
+                {
+                    List<ItemInfoSetting> Weaponlist = new List<ItemInfoSetting>();
+                    foreach (ItemInfoSetting weapon in Server.SettingRepository.ItemInfo.Values)
+                    {
+                        if (weapon.Id > 10100101 & weapon.Id < 15300101)
+                        {
+                            Weaponlist.Add(weapon);
+                        }
+                    }
+
+                    int baseId = Weaponlist[Util.GetRandomNumber(0, Weaponlist.Count)].Id;
+                    itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
+
+                    RecvItemInstanceUnidentified recvItemInstanceUnidentified = new RecvItemInstanceUnidentified(client, itemInstance, (byte)itemInstance.Location.ZoneType);
+                    Router.Send(client, recvItemInstanceUnidentified.ToPacket());
+                }
+                else if (client.Character.eventSelectExecCode == 1)
+                {
+                    List<ItemInfoSetting> ArmorList = new List<ItemInfoSetting>();
+                    foreach (ItemInfoSetting armor in Server.SettingRepository.ItemInfo.Values)
+                    {
+                        if (armor.Id > 16100101 & armor.Id < 30499901)
+                        {
+                            ArmorList.Add(armor);
+                        }
+                    }
+
+                    int baseId = ArmorList[Util.GetRandomNumber(0, ArmorList.Count)].Id;
+                    itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
+
+                    RecvItemInstanceUnidentified recvItemInstanceUnidentified = new RecvItemInstanceUnidentified(client, itemInstance, (byte)itemInstance.Location.ZoneType);
+                    Router.Send(client, recvItemInstanceUnidentified.ToPacket());
+                }
+                else if (client.Character.eventSelectExecCode == 2)
+                { //50401040,Moist Cudgel
+                    int baseId = 50401040; //This can select from a small array of items, and a small array of custom names
+                    spawmParam.ItemStatuses = ItemStatuses.Identified;
+                    itemInstance = itemService.SpawnItemInstance(ItemZoneType.AdventureBag, baseId, spawmParam);
+
+                    RecvItemInstance recvItemInstance = new RecvItemInstance(client, itemInstance);
+                    Router.Send(client, recvItemInstance.ToPacket());
+                }
+
+                if (itemInstance == null)
+                {
+                    res = BufferProvider.Provide();
+                    res.WriteCString("Better Luck Next Time.  I ran out of items!"); // Length 0xC01
+                    Router.Send(client, (ushort)AreaPacketId.recv_event_system_message, res, ServerType.Area); // show system message on middle of the screen.
+                    res = BufferProvider.Provide();
+                    Router.Send(client, (ushort)AreaPacketId.recv_situation_end, res, ServerType.Area);
+                    RecvEventEnd(client); //End The Event 
+                    return;
+                }
+                res = BufferProvider.Provide();
+                res.WriteCString($"Enjoy your new Super {itemInstance.UnidentifiedName}"); // Length 0xC01
+                Router.Send(client, (ushort)AreaPacketId.recv_event_system_message, res, ServerType.Area); // show system message on middle of the screen.
+            }
             res = BufferProvider.Provide();
             Router.Send(client, (ushort)AreaPacketId.recv_situation_end, res, ServerType.Area);
             RecvEventEnd(client); //End The Event 

--- a/Necromancy.Server/Packet/Area/send_forge_execute.cs
+++ b/Necromancy.Server/Packet/Area/send_forge_execute.cs
@@ -86,6 +86,7 @@ namespace Necromancy.Server.Packet.Area
             }
             else if (supportItemCount == 0)
             {
+                itemService.Remove(itemInstance.Location, itemInstance.Quantity);
                 RecvItemRemove recvItemRemove = new RecvItemRemove(client, itemInstance);
                 Router.Send(recvItemRemove);
             }
@@ -128,15 +129,23 @@ namespace Necromancy.Server.Packet.Area
             for (int i = 0; i < forgeItemCount; i++)
             {
                 ItemInstance forgeItemInstance = client.Character.ItemManager.GetItem(new ItemLocation((ItemZoneType)forgeItemStorageType[i], forgeItemBag[i], forgeItemSlot[i]));
-                RecvItemRemove recvItemRemove = new RecvItemRemove(client, forgeItemInstance);
-                Router.Send(recvItemRemove);
+                if (forgeItemInstance != null)
+                {
+                    RecvItemRemove recvItemRemove = new RecvItemRemove(client, forgeItemInstance);
+                    Router.Send(recvItemRemove);
+                    itemService.Remove(forgeItemInstance.Location, forgeItemInstance.Quantity);
+                }
 
             }
             for (int i = 0; i < supportItemCount; i++)
             {
                 ItemInstance supportItemInstance = client.Character.ItemManager.GetItem(new ItemLocation((ItemZoneType)supportItemStorageType, supportItemBag, supportItemSlot));
-                RecvItemRemove recvItemRemove = new RecvItemRemove(client, supportItemInstance);
-                Router.Send(recvItemRemove);
+                if (supportItemInstance != null)
+                {
+                    RecvItemRemove recvItemRemove = new RecvItemRemove(client, supportItemInstance);
+                    Router.Send(recvItemRemove);
+                    itemService.Remove(supportItemInstance.Location, supportItemInstance.Quantity);
+                }
             }
 
 

--- a/Necromancy.Server/Packet/Area/send_login_news_get_url.cs
+++ b/Necromancy.Server/Packet/Area/send_login_news_get_url.cs
@@ -19,7 +19,7 @@ namespace Necromancy.Server.Packet.Area
             IBuffer res = BufferProvider.Provide();
             res.WriteByte(0); //Bool
             res.WriteCString("");
-            Router.Send(client.Map, (ushort) AreaPacketId.recv_login_news_url_notify, res, ServerType.Area);
+            Router.Send(client, (ushort) AreaPacketId.recv_login_news_url_notify, res, ServerType.Area);
         }
     }
 }

--- a/Necromancy.Server/Packet/Area/send_loot_access_object.cs
+++ b/Necromancy.Server/Packet/Area/send_loot_access_object.cs
@@ -31,10 +31,11 @@ namespace Necromancy.Server.Packet.Area
             int instanceID = packet.Data.ReadInt32();
             MonsterSpawn monster = client.Map.GetMonsterByInstanceId((uint) instanceID);
             Logger.Debug($"{client.Character.Name} is trying to loot object {instanceID}.  Inventory Space {client.Character.ItemManager.GetTotalFreeSpace(ItemZoneType.AdventureBag)}");
+            ItemLocation nextOpenLocation = client.Character.ItemManager.NextOpenSlot(ItemZoneType.AdventureBag);
 
             if (monster == null) result = -10;
             else if (monster.loot.ItemCountRNG == 0) result = -1;
-            else if (client.Character.ItemManager.GetTotalFreeSpace(ItemZoneType.AdventureBag) < 2) result = -207; //expand to all inventory. TODO            
+            else if (nextOpenLocation.ZoneType == ItemZoneType.InvalidZone) result = -207; //expand to all inventory. TODO            
 
             IBuffer res2 = BufferProvider.Provide();
             res2.WriteInt32(result);

--- a/Necromancy.Server/Packet/Area/send_loot_access_object.cs
+++ b/Necromancy.Server/Packet/Area/send_loot_access_object.cs
@@ -30,11 +30,11 @@ namespace Necromancy.Server.Packet.Area
             int result = 0;
             int instanceID = packet.Data.ReadInt32();
             MonsterSpawn monster = client.Map.GetMonsterByInstanceId((uint) instanceID);
-            Logger.Debug($"{client.Character.Name} is trying to loot object {instanceID}");
+            Logger.Debug($"{client.Character.Name} is trying to loot object {instanceID}.  Inventory Space {client.Character.ItemManager.GetTotalFreeSpace(ItemZoneType.AdventureBag)}");
 
             if (monster == null) result = -10;
             else if (monster.loot.ItemCountRNG == 0) result = -1;
-            else if (client.Character.ItemManager.GetTotalFreeSpace(ItemZoneType.AdventureBag) < 1) result = -207; //expand to all inventory. TODO            
+            else if (client.Character.ItemManager.GetTotalFreeSpace(ItemZoneType.AdventureBag) < 2) result = -207; //expand to all inventory. TODO            
 
             IBuffer res2 = BufferProvider.Provide();
             res2.WriteInt32(result);

--- a/Necromancy.Server/Packet/Area/send_shop_close.cs
+++ b/Necromancy.Server/Packet/Area/send_shop_close.cs
@@ -21,8 +21,8 @@ namespace Necromancy.Server.Packet.Area
             RecvShopClose shopClose = new RecvShopClose();
             Router.Send(shopClose, client);
 
-            RecvShopNotifyClose notifyClose = new RecvShopNotifyClose();
-            Router.Send(client.Map, notifyClose, client);
+            //RecvShopNotifyClose notifyClose = new RecvShopNotifyClose();
+            //Router.Send(client.Map, notifyClose, client);//Causes other client's shops to close, can't be used on self.
 
             RecvEventSync syncEvent = new RecvEventSync();
             Router.Send(syncEvent, client);

--- a/Necromancy.Server/Packet/Msg/send_friend_accept_request_link.cs
+++ b/Necromancy.Server/Packet/Msg/send_friend_accept_request_link.cs
@@ -19,7 +19,7 @@ namespace Necromancy.Server.Packet.Msg
             int acceptOrDenyResponse = packet.Data.ReadByte();
             IBuffer res = BufferProvider.Provide();
             res.WriteInt32(acceptOrDenyResponse); // 0 = Deny, 1 = Accept
-            res.WriteUInt32(friendInstanceId); // ??
+            res.WriteUInt32(friendInstanceId); // Object ID
             Router.Send(client, (ushort) MsgPacketId.recv_friend_reply_to_link_r, res, ServerType.Msg);
             SendFriendNotifyAddMember(client);
             SendFriendNotifyAddMember(client, friendInstanceId);
@@ -35,8 +35,11 @@ namespace Necromancy.Server.Packet.Msg
             res.WriteFixedString($"{targetClient.Character.Name}", 0x5B); //character name
             res.WriteUInt32(targetClient.Character.ClassId); // Class 0 = Fighter, 1 = thief, ect....
             res.WriteByte(targetClient.Character.Level); // Level of the friend
+            res.WriteByte(0);
             res.WriteInt32(targetClient.Character.MapId); // Location of your friend
             res.WriteInt32(0);
+            res.WriteInt32(0);
+            res.WriteByte(0);
             res.WriteFixedString($"Channel {targetClient.Character.Channel}", 0x61); // Channel location
             res.WriteInt32(0);
             res.WriteInt32(0);
@@ -53,8 +56,11 @@ namespace Necromancy.Server.Packet.Msg
             res.WriteFixedString($"{client.Character.Name}", 0x5B); //character name
             res.WriteUInt32(client.Character.ClassId); // Class 0 = Fighter, 1 = thief, ect....
             res.WriteByte(client.Character.Level); // Level of the friend
+            res.WriteByte(0);
             res.WriteInt32(client.Character.MapId); // Location of your friend
             res.WriteInt32(0);
+            res.WriteInt32(0);
+            res.WriteByte(0);
             res.WriteFixedString($"Channel {client.Character.Channel}",
                 0x61); // When i put the channel it doesn't add the friend, need to fix that.
             res.WriteInt32(0);

--- a/Necromancy.Server/Systems/Item/ItemQualities.cs
+++ b/Necromancy.Server/Systems/Item/ItemQualities.cs
@@ -12,6 +12,7 @@ namespace Necromancy.Server.Systems.Item
         Master      = 1 << 4,
         Legend      = 1 << 5,
         Artifact    = 1 << 6,
+        Epic        = 1 << 7,
         OTHER       = None
     }
 }

--- a/Necromancy.Server/Systems/Item/ItemService.cs
+++ b/Necromancy.Server/Systems/Item/ItemService.cs
@@ -181,7 +181,11 @@ namespace Necromancy.Server.Systems.Item
             }
             foreach (ItemInstance itemInstance in ownedItems)
             {
-
+                if (itemInstance.Location.Slot < 0) //remove invalid db rows on login.
+                {
+                    _itemDao.DeleteItemInstance(itemInstance.InstanceID);
+                    continue;
+                }
                 if (itemInstance.Location.ZoneType != ItemZoneType.BagSlot)
                 {
                     ItemLocation location = itemInstance.Location; //only needed on load inventory because item's location is already populated and it is not in the manager
@@ -209,7 +213,15 @@ namespace Necromancy.Server.Systems.Item
                     itemInstance.Weight = (short)(itemInstance.Weight - forgeMultiplier.Weight);
                     if (itemInstance.Weight < 0) { itemInstance.Weight = 0; } //this is lazy, fix the weight math issue.
 
-                    _character.ItemManager.PutItem(location, itemInstance);
+                    if (location.ZoneType == ItemZoneType.AdventureBag && location.Slot > 23) //Temporary Bug fix for index out of range . todo: fix next slots detection.
+                    {
+                        _itemDao.DeleteItemInstance(itemInstance.InstanceID);
+                        continue;                      
+                    }
+                    else
+                    {
+                        _character.ItemManager.PutItem(location, itemInstance);
+                    }
                 }
                 if (itemInstance.CurrentEquipSlot != ItemEquipSlots.None)
                 {

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ but will eventually be merged back into develop (to definitely add the new featu
 # Attribution
 ## Contributors
 - Unknownone69 [@Unknownone69](https://github.com/Unknownone69) 
+- Nothilvien [@sebastian-heinz](https://github.com/sebastian-heinz)
 - WizOnHiraeth [@WizOnHiraeth](https://github.com/WizOnHiraeth) 
 - blackice36 [@blackice36](https://github.com/blackice36) 
 - Aidoxilia [@Aidoxilia](https://github.com/Aidoxilia) 
@@ -183,7 +184,7 @@ but will eventually be merged back into develop (to definitely add the new featu
 - koffeeMist [@koffeeMist](https://github.com/koffeeMist) 
 - WIZONMAGLOVE [@WIZONMAGLOVE](https://github.com/WIZONMAGLOVE) 
 - Wolfzennn [@Wolfzennn](https://github.com/Wolfzennn)
-- Nothilvien [@sebastian-heinz](https://github.com/sebastian-heinz)
+- Raezaiel [@Raezaiel](https://github.com/Raezaiel) 
 
 ## 3rd Parties and Libraries
 - System.Data.SQLite (https://system.data.sqlite.org/)


### PR DESCRIPTION
This fix corrects the following :

Test Cases:

- log in to 1234 and open a shop.  log in to ff and open a shop.  have 1234 close the shop.  ff shop should remain open
- open the news on 1234. it should not open for ff
- go kill a bunch of enemies in caligrase, and loot until your inventory is full.   It should report on screen that it's full
- go to random item guy with full inventory and try to get some stuff.  He should tell you no.
- Friend request ff from 1234.  that should work! and add friend list entries for both players
- forge some items.   Consumed or broken gear should be removed from inventory and db
- spawn an epic item /itm 11310804  
- -log off and log in should no longer break your inventory.
- - log off and log in.  your adventure bag inventory should be persistent
- - log off and log in to confirm forge stuff

