### PR TITLE
Fix november community bug reports

### DIFF
--- a/Necromancy.Cli/Program.cs
+++ b/Necromancy.Cli/Program.cs
@@ -344,7 +344,7 @@ namespace Necromancy.Cli
             StringBuilder sb = new StringBuilder();
             sb.Append(Environment.NewLine);
             sb.Append(Environment.NewLine);
-            sb.Append("Necromancy.Cli Copyright (C) 2019-2020 Necromancy Team");
+            sb.Append("Necromancy.Cli Copyright (C) 2019-2021 Necromancy Team");
             sb.Append(Environment.NewLine);
             sb.Append("This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.");
             sb.Append(Environment.NewLine);

--- a/Necromancy.Server/Model/CharacterModel/Character.cs
+++ b/Necromancy.Server/Model/CharacterModel/Character.cs
@@ -78,12 +78,13 @@ namespace Necromancy.Server.Model
             stepCount = 0;
             lootNotify = new ItemLocation(0, 0, 0);
             odRecoveryRate = 0;
-            statusEffects = new uint[4]
+            statusEffects = new uint[5]
             {
                 (uint)Statuses.AttackAura405,
                 (uint)Statuses.MosquitoBuzz200,
                 (uint)Statuses.PorkulCakeWhole,
-                (uint)Statuses.ChimeraKillerHotMode
+                (uint)Statuses.ChimeraKillerHotMode,
+                (uint)Statuses.IncreaseGpRecoverySpeed
             };
             tradeWindowSlot = new ulong[20];
         }

--- a/Necromancy.Server/Packet/Area/SendBattleAttackExec.cs
+++ b/Necromancy.Server/Packet/Area/SendBattleAttackExec.cs
@@ -120,8 +120,7 @@ namespace Necromancy.Server.Packet.Area
             {
                 double distanceToObject =
                     Distance(monsterSpawn.x, monsterSpawn.y, client.character.x, client.character.y);
-                _Logger.Debug(
-                    $"target Monster name [{monsterSpawn.name}] distanceToObject [{distanceToObject}] Radius [{monsterSpawn.radius}] {monsterSpawn.name}");
+                //_Logger.Debug($"target Monster name [{monsterSpawn.name}] distanceToObject [{distanceToObject}] Radius [{monsterSpawn.radius}] {monsterSpawn.name}");
                 if (distanceToObject > monsterSpawn.radius * 5
                 ) //increased hitbox for monsters by a factor of 5.  Beetle radius is 40
                     continue;
@@ -155,9 +154,19 @@ namespace Necromancy.Server.Packet.Area
             foreach (NpcSpawn npcSpawn in client.map.npcSpawns.Values)
             {
                 double distanceToObject = Distance(npcSpawn.x, npcSpawn.y, client.character.x, client.character.y);
-                _Logger.Debug(
-                    $"target NPC name [{npcSpawn.name}] distanceToObject [{distanceToObject}] Radius [{npcSpawn.radius}] {npcSpawn.name}");
+               // _Logger.Debug($"target NPC name [{npcSpawn.name}] distanceToObject [{distanceToObject}] Radius [{npcSpawn.radius}] {npcSpawn.name}");
                 if (distanceToObject > npcSpawn.radius) continue;
+
+                //attacking an NPC is a misdimeanor crime for non-criminals.
+                if ((client.character.criminalState == 0))
+                {
+                    client.character.criminalState += 1;
+                    IBuffer res40 = BufferProvider.Provide();
+                    res40.WriteUInt32(client.character.instanceId);
+                    res40.WriteByte(client.character.criminalState);
+
+                    router.Send(client.map, (ushort)AreaPacketId.recv_chara_update_notify_crime_lv, res40, ServerType.Area);
+                }
 
                 DamageTheObject(client, npcSpawn.instanceId, damage, perHp);
             }

--- a/Necromancy.Server/Packet/Area/SendSkillRequestGain.cs
+++ b/Necromancy.Server/Packet/Area/SendSkillRequestGain.cs
@@ -53,8 +53,8 @@ namespace Necromancy.Server.Packet.Area
 
             res.WriteInt32(skillId);
             res.WriteInt32(skillLevel); //Level of skill (1-7)
-            res.WriteByte(1); //Bool
-            res.WriteByte(1); //Bool
+            res.WriteByte(0); //Bool  Transferred skill. 1 = yes
+            res.WriteByte(0); //Bool
 
             router.Send(client, (ushort)AreaPacketId.recv_skill_tree_gain, res, ServerType.Area);
         }

--- a/Necromancy.Server/Packet/Area/SendSkillRequestGain.cs
+++ b/Necromancy.Server/Packet/Area/SendSkillRequestGain.cs
@@ -4,6 +4,7 @@ using Necromancy.Server.Common;
 using Necromancy.Server.Logging;
 using Necromancy.Server.Model;
 using Necromancy.Server.Packet.Id;
+using Necromancy.Server.Packet.Receive.Area;
 
 namespace Necromancy.Server.Packet.Area
 {
@@ -41,6 +42,9 @@ namespace Necromancy.Server.Packet.Area
             }
 
             SendSkillTreeGain(client, skillId, skillLevel);
+            client.character.skillPoints -= 1; //remove 1 skillpoint.  ToDo - ensure character has skill points 
+            RecvSelfSkillPointNotify recvSelfSkillPointNotify = new RecvSelfSkillPointNotify(client.character.skillPoints);
+            router.Send(recvSelfSkillPointNotify, client);
 
             IBuffer res = BufferProvider.Provide();
             res.WriteInt32(0); //1 = failed to aquire skill, 0 = success? but no skill aquired

--- a/Necromancy.Server/Tasks/CharacterTask.cs
+++ b/Necromancy.Server/Tasks/CharacterTask.cs
@@ -19,7 +19,7 @@ namespace Necromancy.Server.Tasks
 
     {
         private static readonly NecLogger _Logger = LogProvider.Logger<NecLogger>(typeof(CharacterTask));
-        private readonly NecClient _client;
+        private NecClient _client;
 
         private readonly object _logoutLock = new object();
         private readonly NecServer _server;
@@ -50,6 +50,9 @@ namespace Necromancy.Server.Tasks
             if (_client == null) Stop(); //crash/disconnect handling
             while (_client.character.characterActive)
             {
+                _tickCounter++;
+                //_Logger.Debug($"Character {_client.character.name} is on task tick : {_tickCounter}");
+
                 if (_logoutTime != DateTime.MinValue)
                     if (DateTime.Now >= _logoutTime)
                         LogOutRequest();
@@ -61,14 +64,13 @@ namespace Necromancy.Server.Tasks
 
                 StatRegen();
 
-                if (_tickCounter == 600)
+                if (_tickCounter >= 60) //set to 600 or 1200 for 5 minutes or 10 minutes. true to game is 10 minutes. 
                 {
+                    _tickCounter = 0;
                     CriminalRepent();
                     SoulMaterialIncrease();
-                    _tickCounter = 0;
                 }
 
-                _tickCounter++;
                 Thread.Sleep(_tickTime);
             }
 
@@ -76,9 +78,23 @@ namespace Necromancy.Server.Tasks
         }
 
         private void CriminalRepent()
-        {            
-            if (_client.soul.criminalLevel > 0) _client.soul.criminalLevel--;
-            _client.character.criminalState = _client.soul.criminalLevel;
+        {
+            //_Logger.Debug($"Character {_client.character.name} criminal state is : {_client.character.criminalState}");
+
+            if (_client.character.criminalState > 0)
+            {
+                if (_client.soul.criminalLevel > 0) _client.soul.criminalLevel--;
+                if (_client.soul.criminalLevel < 0) _client.soul.criminalLevel = 0;
+                _client.character.criminalState = _client.soul.criminalLevel;
+                if ((_client.character.criminalState < 3))
+                {
+                    IBuffer res40 = BufferProvider.Provide();
+                    res40.WriteUInt32(_client.character.instanceId);
+                    res40.WriteByte(_client.character.criminalState);
+                    _server.router.Send(_client.map, (ushort)AreaPacketId.recv_chara_update_notify_crime_lv, res40, ServerType.Area);
+                }
+            }
+            //_Logger.Debug($"Character {_client.character.name} criminal new state is : {_client.character.criminalState}");
         }
 
         private void SoulMaterialIncrease()

--- a/Necromancy.Server/Tasks/CharacterTask.cs
+++ b/Necromancy.Server/Tasks/CharacterTask.cs
@@ -76,10 +76,8 @@ namespace Necromancy.Server.Tasks
         }
 
         private void CriminalRepent()
-        {
-            _client.soul.criminalLevel--;
-            if (_client.soul.criminalLevel <= 0) _client.soul.criminalLevel = 0;
-
+        {            
+            if (_client.soul.criminalLevel > 0) _client.soul.criminalLevel--;
             _client.character.criminalState = _client.soul.criminalLevel;
         }
 

--- a/Necromancy.Server/Tasks/CharacterTask.cs
+++ b/Necromancy.Server/Tasks/CharacterTask.cs
@@ -121,7 +121,7 @@ namespace Necromancy.Server.Tasks
                 RecvCharaUpdateAp recvCharaUpdateAp = new RecvCharaUpdateAp(_client.character.od.current);
                 _server.router.Send(recvCharaUpdateAp, _client);
             }
-            else if (_client.character.od.current < _client.character.od.max)
+            else if (_client.character.od.current < 100 /*_client.character.od.max*/)
             {
                 _client.character.od.SetCurrent(_client.character.od.current + _client.character.odRecoveryRate / 2);
                 RecvCharaUpdateAp recvCharaUpdateAp = new RecvCharaUpdateAp(_client.character.od.current);


### PR DESCRIPTION
This PR fixes criminal state on revive. players will no longer turn criminal.  (-1 == 255).  It also fixes repentance, and makes you yellow if you attack an NPC.    Lastly, some minor tweaks to skill  point usage on skill leveling. 

Test Cases:
1.)  Log in to a character with 0 crime level (or create a new one).  Attack an NPC.  Turn yellow.
2.) /died yourself.  /revi yourself.   be amazed that you have no longer turned red for your non-crime of coming back from the dead.
3.) learn a skill from the skill tree.  close and re-open the skill window.   notice your skill point availability count has reduced by 1, and your skill is not set as a carry-over skill (bottom sections with 5 little spots for icons on the skill window should be empty)
4.)  Run around until you run out of OD.   watch it auto-recover to just 100.   Be sad that you can only run half as far..... 



